### PR TITLE
hostPath and tls improvements

### DIFF
--- a/k8s-webdav/templates/deployment.yaml
+++ b/k8s-webdav/templates/deployment.yaml
@@ -61,19 +61,26 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-         - name: httpd-conf
-           configMap:
-             name: httpd-conf
-             defaultMode: 0644
-         - name: htpasswd
-           configMap:
-             name: htpasswd
-             defaultMode: 0644
-         {{- if .Values.persistence.enabled }}
-         - name: data
-           persistentVolumeClaim:
-             claimName: {{ .Values.persistence.existingClaim | default (include "webdav.fullname" .) }}
-         {{- end }}
+        - name: httpd-conf
+          configMap:
+            name: httpd-conf
+            defaultMode: 0644
+        - name: htpasswd
+          configMap:
+            name: htpasswd
+            defaultMode: 0644
+      {{- if .Values.persistence.enabled }}
+        - name: data
+        {{- if eq .Values.persistence.type "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "webdav.fullname" .) }}
+        {{- else if eq .Values.persistence.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.persistence.hostPath }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s-webdav/templates/ingress.yaml
+++ b/k8s-webdav/templates/ingress.yaml
@@ -19,7 +19,9 @@ spec:
             name: {{ include "webdav.fullname" . }}
             port:
               number: 80
+{{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.ingress.host }}
-    secretName: webdav-tls-secret
+    secretName: {{ .Values.ingress.tls.secret }}
+{{- end }}

--- a/k8s-webdav/values.yaml
+++ b/k8s-webdav/values.yaml
@@ -26,6 +26,9 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: "600"
 #    kubernetes.io/tls-acme: "true"
+  tls:
+    enabled: true
+    secret: webdav-tls-secret
 
 persistence:
   enabled: false


### PR DESCRIPTION
- Allow using hostPath for the `persistency` by following common patterns.
- Allow to disable TLS and customize the secret name instead of hardcoding made-up values.