### PR TITLE
Add feature to use existing secrets.

### DIFF
--- a/k8s-webdav/templates/_helpers.tpl
+++ b/k8s-webdav/templates/_helpers.tpl
@@ -51,3 +51,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Logic to make httpasswd filename generated based on URL's paths
+*/}}
+{{- define "returnUrlPathHtpasswdFilename" -}}
+{{- printf "%s" . | replace "/" "" | default "-" -}}
+{{- end }}

--- a/k8s-webdav/templates/configmap.yaml
+++ b/k8s-webdav/templates/configmap.yaml
@@ -12,10 +12,14 @@ kind: ConfigMap
 metadata:
   name: htpasswd
 data:
-  {{- range $path, $users := .Values.urls }}
-  {{ $path | replace "/" "" | default "-" }}: |-
-      {{ range $user := $users }}
-      {{- htpasswd $user.user $user.password }}
-      {{ end }}
+{{- range $path, $users := .Values.urls }}
+  {{- if kindIs "slice" $users }}
+  {{ include "returnUrlPathHtpasswdFilename" $path }}: |-
+    {{ range $user := $users }}
+      {{- $username := $user.user | required ".Values.urls[*].user is required if if the URL value is defined as list" }}
+      {{- $password := $user.password | required ".Values.urls[*].password is required if if the URL value is defined as list" }}
+      {{- htpasswd $username $password }}
+    {{- end }}
   {{- end }}
+{{- end }}
 

--- a/k8s-webdav/templates/deployment.yaml
+++ b/k8s-webdav/templates/deployment.yaml
@@ -36,20 +36,17 @@ spec:
             - mkdir /usr/local/apache2/{webdav,var};
               touch /usr/local/apache2/var/DavLock;
               chown -R www-data:www-data /usr/local/apache2/{webdav,var};
-              su www-data -s /bin/bash -c '
-              for path in /usr/local/apache2/htpasswd.d/*;
-              do
-                  dir=$(basename $path);
-                  if [[ "$dir" != "-" ]]; then mkdir -p /usr/local/apache2/webdav/$dir; fi;
-              done
-              ';
               httpd-foreground
           volumeMounts:
             - name: httpd-conf
               mountPath: /usr/local/apache2/conf/httpd.conf
               subPath: httpd.conf
             - name: htpasswd
-              mountPath: /usr/local/apache2/htpasswd.d
+              mountPath: /usr/local/apache2/htpasswd.d/generated
+          {{- range $existingHtpasswdSecret := .Values.existingHtpasswdSecrets }}
+            - name: existing-htpasswd-{{ $existingHtpasswdSecret.name }}
+              mountPath: /usr/local/apache2/htpasswd.d/existing/{{ $existingHtpasswdSecret.name }}
+          {{- end }}
           {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /usr/local/apache2/webdav
@@ -69,6 +66,12 @@ spec:
           configMap:
             name: htpasswd
             defaultMode: 0644
+      {{- range $existingHtpasswdSecret := .Values.existingHtpasswdSecrets }}
+        - name: existing-htpasswd-{{ $existingHtpasswdSecret.name }}
+          secret:
+            secretName: {{ $existingHtpasswdSecret.name }}
+            defaultMode: 0644
+      {{- end }}
       {{- if .Values.persistence.enabled }}
         - name: data
         {{- if eq .Values.persistence.type "pvc" }}

--- a/k8s-webdav/values.yaml
+++ b/k8s-webdav/values.yaml
@@ -1,12 +1,19 @@
 urls: {}
-#  /:
-#  - user: user1
-#    password: password1
-#  - user: user2
-#    password: password2
-#  /foo:
-#  - user: user3
-#    password: password3
+  # /:
+  # - user: user1
+  #  password: password1
+  # - user: user2
+  #  password: password2
+  # /foo:
+  # - user: user3
+  #   password: password3
+  # /bar:
+  #   htpasswdSecretRef:
+  #     name: my-existing-htpasswd-secret
+  #     key: file
+
+# existingHtpasswdSecrets:
+#   - name: my-existing-htpasswd-secret
 
 service:
   type: ClusterIP
@@ -108,7 +115,12 @@ httpd_conf: |-
       AllowOverride None
       AuthType Basic
       AuthName "Restricted area"
-      AuthUserFile /usr/local/apache2/htpasswd.d/{{ $url | default "-" }}
+    {{- if kindIs "slice" $users }}
+      AuthUserFile /usr/local/apache2/htpasswd.d/generated/{{ include "returnUrlPathHtpasswdFilename" $path }}
+    {{- else if kindIs "map" $users }}
+      {{- $htpasswdSecretRef := $users.htpasswdSecretRef | required ".Values.urls.[*].htpasswdSecretRef is required if if the url value is defined as map" }}
+      AuthUserFile /usr/local/apache2/htpasswd.d/existing/{{ $htpasswdSecretRef.name }}/{{ $htpasswdSecretRef.key }}
+    {{- end }}
       Require valid-user
   </Directory>
   {{- end }}


### PR DESCRIPTION
This feature enables to store/deploy kubernetes resources in a GitOps, where the configuration is public/exposed. By using existing secret, it can be created in a safe manner using [external-secrets](https://external-secrets.io/) or [sealed-secrets](https://sealed-secrets.netlify.app/).

Some items and path got `existing` and `generated` prefix in order to avoid naming collisions.