### PR TITLE
Remove download dir owner setting for hostPath.

### DIFF
--- a/k8s-webdav/README.md
+++ b/k8s-webdav/README.md
@@ -88,6 +88,19 @@ Apply it:
 kubectl apply -f htpasswd-secret.yaml
 ```
 
+### Use HostPath persistency
+
+HostPath can be configured for the persistency type, which mounts a directory from the host.
+
+```YAML
+persistence:
+  enabled: true
+  type: hostPath
+  hostPath: /path/on/host
+```
+
+In this case, it is the user's responsibility to grant permission to the UID:33 GID:33 (www-data) user to manage this directory.
+
 ### Deploy the WebDav server to Kubernetes:
 ```
 helm repo add k8s-webdav https://danuk.github.io/k8s-webdav/

--- a/k8s-webdav/templates/deployment.yaml
+++ b/k8s-webdav/templates/deployment.yaml
@@ -35,7 +35,10 @@ spec:
           args:
             - mkdir /usr/local/apache2/{webdav,var};
               touch /usr/local/apache2/var/DavLock;
-              chown -R www-data:www-data /usr/local/apache2/{webdav,var};
+            {{- if ne .Values.persistence.type "hostPath" }}
+              chown -R www-data:www-data /usr/local/apache2/webdav;
+            {{- end }}
+              chown -R www-data:www-data /usr/local/apache2/var;
               httpd-foreground
           volumeMounts:
             - name: httpd-conf


### PR DESCRIPTION
For hostPath persistency, it is not a wise choice to take over directory ownership on the host machine.
This feature is disabled for hostPath and the README was updated to ask the user to grant the permissions themself.